### PR TITLE
Simplified pairing logic

### DIFF
--- a/cmd/duplextools/pair.go
+++ b/cmd/duplextools/pair.go
@@ -25,7 +25,7 @@ func runPair(args []string) {
 	bed := pairFlags.String("bed", "", "Output a bed file with the region covered by each read family. May significantly increase memory usage.")
 	strict := pairFlags.Bool("strict", false, "Require perfect barcode match for family inclusion. Disables position matching. Use for high density data.")
 	tolerance := pairFlags.Int("tolerance", 50, "Deviation from exact start match to be considered for inclusion in read family. 0 means perfect match. Low values are best for dense data, and high values are best for sparse data.")
-	strictPosMatching := pairFlags.Bool("strictPosMatching", false, "For a read to be included in a read family, the start of both reads in a pair must exactly match the read family.")
+	strictPosMatching := pairFlags.Bool("strictPosMatching", false, "For a read to be included in a read family, the boundaries of both reads in a pair (start of fwd read/end of rev read) must exactly match read family.")
 	minMapQ := pairFlags.Int("minMapQ", 20, "Minimum mapping quality.")
 
 	err = pairFlags.Parse(args)

--- a/families/families.go
+++ b/families/families.go
@@ -63,8 +63,7 @@ func annotate(in <-chan sam.Sam, out chan<- sam.Sam, startTolerance int, posMatc
 		if currFam == nil {
 			currFam = new(family)
 			currFam.chr = r.GetChrom()
-			currFam.start = r.GetChromStart()
-			currFam.end = r.GetChromEnd()
+			currFam.start, currFam.end = getFamilyBoundaries(&r)
 			currFam.mateStart = int(r.PNext) - 1
 			m[id] = currFam
 		}
@@ -107,47 +106,36 @@ func findFamily(r *sam.Sam, readNameMap map[string]uint, startTolerance int, pos
 		return familyDetermination
 	}
 
-	// TODO: SIMPLIFY THIS LOGIC
-
 	switch {
 	// check match for current family
-	case posMatching && r.RName == currFam.chr && (r.GetChromStart() == currFam.start || r.GetChromEnd() == currFam.end || int(r.PNext)-1 == currFam.start || r.GetChromStart() == currFam.mateStart) && (!strictPosMatching || (strictPosMatching && matePositionsMatch(r, currFam))): // start/end match, probably part of existing family
+	case posMatching && r.RName == currFam.chr && familyBoundariesMatch(r, currFam, 0): // start/end match, probably part of existing family
 		familyDetermination = currFam.familyId
 		if int(r.PNext)-1 != currFam.mateStart {
 			currFam.altMateStarts = append(currFam.altMateStarts, int(r.PNext)-1)
 		}
 
 	// check match for previous family
-	case posMatching && r.RName == prevFam.chr && (r.GetChromStart() == prevFam.start || r.GetChromEnd() == prevFam.end || int(r.PNext)-1 == prevFam.start || r.GetChromStart() == prevFam.mateStart) && (!strictPosMatching || (strictPosMatching && matePositionsMatch(r, prevFam))): // start/end match, probably part of existing family
+	case posMatching && r.RName == prevFam.chr && familyBoundariesMatch(r, prevFam, 0): // start/end match, probably part of existing family
 		familyDetermination = prevFam.familyId
 		if int(r.PNext)-1 != prevFam.mateStart {
 			prevFam.altMateStarts = append(prevFam.altMateStarts, int(r.PNext)-1)
 		}
 
-	// check altStarts match for current family
-	case posMatching && r.RName == currFam.chr && altStartsMatch(r.GetChromStart(), currFam.altMateStarts) && (!strictPosMatching || (strictPosMatching && matePositionsMatch(r, currFam))):
-		familyDetermination = currFam.familyId
-
-	// check altStarts match for previous family
-	case posMatching && r.RName == prevFam.chr && altStartsMatch(r.GetChromStart(), prevFam.altMateStarts) && (!strictPosMatching || (strictPosMatching && matePositionsMatch(r, prevFam))):
-		familyDetermination = prevFam.familyId
-
 	// barcode match, part of current family
-	case r.RName == currFam.chr && r.GetChromStart() <= currFam.start+startTolerance && (!strictPosMatching || (strictPosMatching && matePositionsMatch(r, currFam))):
+	case !strictPosMatching && r.RName == currFam.chr && familyBoundariesMatch(r, currFam, startTolerance):
 		familyDetermination = currFam.familyId
 
 	// barcode match, part of previous family
-	case r.RName == prevFam.chr && r.GetChromStart() <= prevFam.start+startTolerance && (!strictPosMatching || (strictPosMatching && matePositionsMatch(r, prevFam))):
+	case !strictPosMatching && r.RName == prevFam.chr && familyBoundariesMatch(r, prevFam, startTolerance):
 		familyDetermination = prevFam.familyId
 
 	default: // must overwrite existing family
 		*currFamilyId++
 		prevFam, currFam = currFam, prevFam
 		currFam.chr = r.RName
-		currFam.start = r.GetChromStart()
+		currFam.start, currFam.end = getFamilyBoundaries(r)
 		currFam.mateStart = int(r.PNext) - 1
 		currFam.altMateStarts = currFam.altMateStarts[:0] // trim
-		currFam.end = r.GetChromEnd()
 		currFam.familyId = *currFamilyId
 		familyDetermination = currFam.familyId
 	}
@@ -164,15 +152,22 @@ func altStartsMatch(start int, altStarts []int) bool {
 	return false
 }
 
-func matePositionsMatch(r *sam.Sam, fam *family) bool {
-	switch {
-	case r.GetChromStart() == fam.start && int(r.PNext)-1 == fam.mateStart:
+func familyBoundariesMatch(r *sam.Sam, fam *family, tolerance int) bool {
+	templateStart, templateEnd := getFamilyBoundaries(r)
+
+	if templateStart == fam.start && templateEnd == fam.end {
 		return true
-	case r.GetChromStart() == fam.mateStart && int(r.PNext)-1 == fam.start:
-		return true
-	default:
+	}
+
+	if templateStart < fam.start-tolerance || templateStart > fam.start+tolerance {
 		return false
 	}
+
+	if templateEnd < fam.end-tolerance || templateEnd > fam.end+tolerance {
+		return false
+	}
+
+	return true
 }
 
 func getId(a, b string) string {
@@ -203,5 +198,13 @@ func addStrandTag(s *sam.Sam, watsonStrand bool) {
 		s.Extra += fmt.Sprintf("RS:Z:W") // watson
 	} else {
 		s.Extra += fmt.Sprintf("RS:Z:C") // crick
+	}
+}
+
+func getFamilyBoundaries(s *sam.Sam) (start, end int) {
+	if sam.IsPosStrand(*s) {
+		return s.GetChromStart(), s.GetChromStart() + int(s.TLen)
+	} else { // is reverse
+		return s.GetChromEnd() + int(s.TLen), s.GetChromEnd()
 	}
 }

--- a/families/families_test.go
+++ b/families/families_test.go
@@ -1,0 +1,1 @@
+package families


### PR DESCRIPTION
This PR simplifies the pairing logic for building read families so it uses TLen in the sam records to define the start and end of read families rather than doing start position matching of individual reads as it was previously. As a result, family matching is far more stable and correctly handles cases like single-stranded indels which previously would all end up in different read families. 

Resolves #6 